### PR TITLE
Patch for windows take 2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure that script files don't get changed to CRLF on checkout in Windows
+*.sh text eol=lf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,3 +91,7 @@ services:
       - type: bind
         source: ./
         target: /app
+      - node-modules:/app/node_modules
+
+volumes:
+  node-modules:


### PR DESCRIPTION
This is the minimal set of changes required to get `docker-compose up` working under Windows:
 * `.gitattributes` to prevent the conversion of line endings for .sh files
* Moving `node_modules` to its own persistent Docker-managed volume