### PR TITLE
Add endpoints

### DIFF
--- a/src/schema/activity.js
+++ b/src/schema/activity.js
@@ -150,15 +150,29 @@ type MaterialList {
 }
 
 extend type Query {
+    # Get the list of materials
+    materials(page: PaginationInput): MaterialList @beehiveList(target_type_name: "Material")
+    # Get a material
+    getMaterial(material_id: ID!): Material @beehiveGet(target_type_name: "Material")
+    # Get a material (DEPRECATED; use getMaterial instead)
     material(material_id: ID!): Material! @beehiveGet(target_type_name: "Material")
-    materials(query: QueryExpression!, page: PaginationInput): MaterialList! @beehiveQuery(target_type_name: "Material")
+    # Find materials based on one or more of their properties
+    findMaterials(name: String, description: String): MaterialList @beehiveSimpleQuery(target_type_name: "Material")
+    # Find materials using a complex query
+    searchMaterials(query: QueryExpression!, page: PaginationInput): MaterialList @beehiveQuery(target_type_name: "Material")
+
     materialInteraction(material_interaction_id: ID!): MaterialInteraction! @beehiveGet(target_type_name: "MaterialInteraction")
     materialInteractions(query: QueryExpression!, page: PaginationInput): MaterialInteractionList! @beehiveQuery(target_type_name: "MaterialInteraction")
 }
 
 extend type Mutation {
-    # adds a new datapoint to the graph
+    # Create a new material
     createMaterial(material: MaterialInput): Material @beehiveCreate(target_type_name: "Material")
+    # Update a material
+    updateMaterial(material_id: ID!, material: MaterialInput): Material @beehiveUpdate(target_type_name: "Material")
+    # Delete a material
+    deleteMaterial(material_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Material")
+
     createMaterialInteraction(material_interaction: MaterialInteractionInput): MaterialInteraction @beehiveDelete(target_type_name: "MaterialInteraction")
 }
 

--- a/src/schema/activity.js
+++ b/src/schema/activity.js
@@ -157,7 +157,7 @@ extend type Query {
     # Get a material (DEPRECATED; use getMaterial instead)
     material(material_id: ID!): Material! @beehiveGet(target_type_name: "Material")
     # Find materials based on one or more of their properties
-    findMaterials(name: String, description: String): MaterialList @beehiveSimpleQuery(target_type_name: "Material")
+    findMaterials(name: String, description: String, page: PaginationInput): MaterialList @beehiveSimpleQuery(target_type_name: "Material")
     # Find materials using a complex query
     searchMaterials(query: QueryExpression!, page: PaginationInput): MaterialList @beehiveQuery(target_type_name: "Material")
 

--- a/src/schema/activity.js
+++ b/src/schema/activity.js
@@ -116,6 +116,10 @@ input MaterialInput {
     description: String
 }
 
+input MaterialUpdateInput {
+    name: String
+    description: String
+}
 
 input MaterialInteractionInput {
     source: SourceType!
@@ -169,7 +173,7 @@ extend type Mutation {
     # Create a new material
     createMaterial(material: MaterialInput): Material @beehiveCreate(target_type_name: "Material")
     # Update a material
-    updateMaterial(material_id: ID!, material: MaterialInput): Material @beehiveUpdate(target_type_name: "Material")
+    updateMaterial(material_id: ID!, material: MaterialUpdateInput): Material @beehiveUpdate(target_type_name: "Material")
     # Delete a material
     deleteMaterial(material_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Material")
 

--- a/src/schema/data.js
+++ b/src/schema/data.js
@@ -89,12 +89,12 @@ input DatapointInput {
 }
 
 extend type Query {
-    # Gets the list of datapoints
-    datapoints(page: PaginationInput): DatapointList! @beehiveList(target_type_name: "Datapoint")
-    # get a single datapoint using it's ID
+    # Get the list of datapoints
+    datapoints(page: PaginationInput): DatapointList @beehiveList(target_type_name: "Datapoint")
+    # Get a datapoint
     getDatapoint(data_id: ID!): Datapoint @beehiveGet(target_type_name: "Datapoint")
-    # find datapoints using a complex query
-    searchDatapoints(query: QueryExpression!, page: PaginationInput): DatapointList! @beehiveQuery(target_type_name: "Datapoint")
+    # Find people using a complex query
+    searchDatapoints(query: QueryExpression!, page: PaginationInput): DatapointList @beehiveQuery(target_type_name: "Datapoint")
 
     # Get the list of inference executions
     inferenceExecutions(page: PaginationInput): InferenceExecutionList @beehiveList(target_type_name: "InferenceExecution")
@@ -107,9 +107,13 @@ extend type Query {
 }
 
 extend type Mutation {
-    # adds a new datapoint to the graph
+    # Create a new datapoint
     createDatapoint(datapoint: DatapointInput): Datapoint @beehiveCreate(target_type_name: "Datapoint", s3_file_fields: ["file"])
+    # Update a datapoint
+    updateDatapoint(data_id: ID!, datapoint: DatapointInput): Datapoint @beehiveUpdate(target_type_name: "Datapoint")
+    # Delete a datapoint
     deleteDatapoint(data_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Datapoint")
+
     tagDatapoint(data_id: ID!, tags: [String!]!): Datapoint! @beehiveListFieldAppend(target_type_name: "Datapoint", field_name: "tags", input_field_name: "tags")
     untagDatapoint(data_id: ID!, tags: [String!]!): Datapoint! @beehiveListFieldDelete(target_type_name: "Datapoint", field_name: "tags", input_field_name: "tags")
 

--- a/src/schema/data.js
+++ b/src/schema/data.js
@@ -64,6 +64,16 @@ input InferenceExecutionInput {
     execution_start: Datetime!
 }
 
+input InferenceExecutionUpdateInput {
+    name: String
+    notes: String
+    model: String
+    version: String
+    data_sources: [ID!]
+    data_results: [ID!]
+    execution_start: Datetime
+}
+
 enum DataSourceType {
     GROUND_TRUTH
     GENERATED_TEST
@@ -85,6 +95,17 @@ input DatapointInput {
     duration: Int
     source: ID
     source_type: DataSourceType!
+    tags: [String!]
+}
+
+input DatapointUpdateInput {
+    format: String
+    timestamp: Datetime
+    associations: [ID!]
+    parents: [ID!]
+    duration: Int
+    source: ID
+    source_type: DataSourceType
     tags: [String!]
 }
 
@@ -110,7 +131,7 @@ extend type Mutation {
     # Create a new datapoint
     createDatapoint(datapoint: DatapointInput): Datapoint @beehiveCreate(target_type_name: "Datapoint", s3_file_fields: ["file"])
     # Update a datapoint
-    updateDatapoint(data_id: ID!, datapoint: DatapointInput): Datapoint @beehiveUpdate(target_type_name: "Datapoint")
+    updateDatapoint(data_id: ID!, datapoint: DatapointUpdateInput): Datapoint @beehiveUpdate(target_type_name: "Datapoint")
     # Delete a datapoint
     deleteDatapoint(data_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Datapoint")
 
@@ -120,7 +141,7 @@ extend type Mutation {
     # Create a new inference execution
     createInferenceExecution(inferenceExecution: InferenceExecutionInput): InferenceExecution @beehiveCreate(target_type_name: "InferenceExecution")
     # Update an inference execution
-    updateInferenceExecution(inference_id: ID!, inferenceExecution: InferenceExecutionInput): InferenceExecution @beehiveUpdate(target_type_name: "InferenceExecution")
+    updateInferenceExecution(inference_id: ID!, inferenceExecution: InferenceExecutionUpdateInput): InferenceExecution @beehiveUpdate(target_type_name: "InferenceExecution")
     # Delete an inference execution
     deleteInferenceExecution(inference_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "InferenceExecution")
 }

--- a/src/schema/data.js
+++ b/src/schema/data.js
@@ -114,7 +114,7 @@ extend type Query {
     datapoints(page: PaginationInput): DatapointList @beehiveList(target_type_name: "Datapoint")
     # Get a datapoint
     getDatapoint(data_id: ID!): Datapoint @beehiveGet(target_type_name: "Datapoint")
-    # Find people using a complex query
+    # Find datapoints using a complex query
     searchDatapoints(query: QueryExpression!, page: PaginationInput): DatapointList @beehiveQuery(target_type_name: "Datapoint")
 
     # Get the list of inference executions

--- a/src/schema/data.js
+++ b/src/schema/data.js
@@ -96,11 +96,14 @@ extend type Query {
     # find datapoints using a complex query
     searchDatapoints(query: QueryExpression!, page: PaginationInput): DatapointList! @beehiveQuery(target_type_name: "Datapoint")
 
-    # List of all InferenceExecutions
-    inferenceExecutions(page: PaginationInput): InferenceExecutionList! @beehiveList(target_type_name: "InferenceExecution")
+    # Get the list of inference executions
+    inferenceExecutions(page: PaginationInput): InferenceExecutionList @beehiveList(target_type_name: "InferenceExecution")
+    # Get an inference execution
     getInferenceExecution(inference_id: ID!): InferenceExecution! @beehiveGet(target_type_name: "InferenceExecution")
-    findInferenceExecutions(model: String, version: String, name: String, page: PaginationInput): InferenceExecutionList! @beehiveSimpleQuery(target_type_name: "InferenceExecution")
-    searchInferenceExecutions(query: QueryExpression!, page: PaginationInput): InferenceExecutionList! @beehiveQuery(target_type_name: "InferenceExecution")
+    # Find inference executions based on one or more of their properties
+    findInferenceExecutions(name: String, model: String, version: String, page: PaginationInput): InferenceExecutionList @beehiveSimpleQuery(target_type_name: "InferenceExecution")
+    # Find materials using a complex query
+    searchInferenceExecutions(query: QueryExpression!, page: PaginationInput): InferenceExecutionList @beehiveQuery(target_type_name: "InferenceExecution")
 }
 
 extend type Mutation {
@@ -110,10 +113,12 @@ extend type Mutation {
     tagDatapoint(data_id: ID!, tags: [String!]!): Datapoint! @beehiveListFieldAppend(target_type_name: "Datapoint", field_name: "tags", input_field_name: "tags")
     untagDatapoint(data_id: ID!, tags: [String!]!): Datapoint! @beehiveListFieldDelete(target_type_name: "Datapoint", field_name: "tags", input_field_name: "tags")
 
-    # Inference Executions
+    # Create a new inference execution
     createInferenceExecution(inferenceExecution: InferenceExecutionInput): InferenceExecution @beehiveCreate(target_type_name: "InferenceExecution")
-    updateInferenceExecution(inference_id: ID!): InferenceExecution @beehiveUpdate(target_type_name: "InferenceExecution")
-    deleteInferenceExecution(inference_id: ID!): DeleteStatusResponse @beehiveDelete(target_type_name: "InferenceExecution")
+    # Update an inference execution
+    updateInferenceExecution(inference_id: ID!, inferenceExecution: InferenceExecutionInput): InferenceExecution @beehiveUpdate(target_type_name: "InferenceExecution")
+    # Delete an inference execution
+    deleteInferenceExecution(inference_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "InferenceExecution")
 }
 
 

--- a/src/schema/environments.js
+++ b/src/schema/environments.js
@@ -110,7 +110,7 @@ exports.typeDefs = `
     # Get a person
     getPerson(person_id: ID!): Person @beehiveGet(target_type_name: "Person")
     # Find people based on one or more of their properties
-    findPersons(name: String): PersonList @beehiveSimpleQuery(target_type_name: "Person")
+    findPersons(name: String, page: PaginationInput): PersonList @beehiveSimpleQuery(target_type_name: "Person")
     # Find people using a complex query
     searchPersons(query: QueryExpression!, page: PaginationInput): PersonList @beehiveQuery(target_type_name: "Person")
   }

--- a/src/schema/environments.js
+++ b/src/schema/environments.js
@@ -98,12 +98,16 @@ exports.typeDefs = `
   }
 
   extend type Query {
-    # Gets the list of environments
+    # Get the list of environments
     environments(page: PaginationInput): EnvironmentList @beehiveList(target_type_name: "Environment")
-    # Get a sepecific environment
+    # Get an environment
     getEnvironment(environment_id: ID!): Environment @beehiveGet(target_type_name: "Environment")
-    # Search for environments with exact match for name and/or location
+    # Find environments based on one or more of their properties
+    findEnvironments(name: String, location: String, page: PaginationInput): EnvironmentList @beehiveSimpleQuery(target_type_name: "Environment")
+    # Find environments based on one or more of their properties (DEPRECATED, use findEnvironments instead)
     findEnvironment(name: String, location: String): EnvironmentList @beehiveSimpleQuery(target_type_name: "Environment")
+    # Find environments using a complex query
+    searchEnvironments(query: QueryExpression!, page: PaginationInput): EnvironmentList @beehiveQuery(target_type_name: "Environment")
 
     # Get the list of people
     persons(page: PaginationInput): PersonList @beehiveList(target_type_name: "Person")
@@ -116,12 +120,16 @@ exports.typeDefs = `
   }
 
   extend type Mutation {
-    # Create a new Environment
+    # Create a new environment
     createEnvironment(environment: EnvironmentInput): Environment @beehiveCreate(target_type_name: "Environment")
-    # update an Environment
+    # Update a person
     updateEnvironment(environment_id: ID!, environment: EnvironmentInput): Environment @beehiveUpdate(target_type_name: "Environment")
+    # Delete an environment
+    deleteEnvironment(environment_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Environment")
+
     # Assign an assignable to an envionemnt
     assignToEnvironment(assignment: AssignmentInput): Assignment @beehiveCreate(target_type_name: "Assignment")
+
     # Update an assignment to set the end date/time of the assignment
     updateAssignment(assignment_id: ID!, assignment: AssignmentUpdateInput): Assignment @beehiveUpdate(target_type_name: "Assignment")
     # creates a new Layout, which represents the basic shape of an enviroment.

--- a/src/schema/environments.js
+++ b/src/schema/environments.js
@@ -20,6 +20,11 @@ exports.typeDefs = `
     name: String!
   }
 
+  type PersonList {
+    data: [Person!]!
+    page_info: PageInfo!
+  }
+
   enum AssignableTypeEnum {
     PERSON
     DEVICE
@@ -99,6 +104,15 @@ exports.typeDefs = `
     getEnvironment(environment_id: ID!): Environment @beehiveGet(target_type_name: "Environment")
     # Search for environments with exact match for name and/or location
     findEnvironment(name: String, location: String): EnvironmentList @beehiveSimpleQuery(target_type_name: "Environment")
+
+    # Get the list of people
+    persons(page: PaginationInput): PersonList @beehiveList(target_type_name: "Person")
+    # Get a person
+    getPerson(person_id: ID!): Person @beehiveGet(target_type_name: "Person")
+    # Find a person based on one or more of their properties
+    findPersons(name: String): PersonList @beehiveSimpleQuery(target_type_name: "Person")
+    # Find people using a complex query
+    searchPersons(query: QueryExpression!, page: PaginationInput): PersonList @beehiveQuery(target_type_name: "Person")
   }
 
   extend type Mutation {
@@ -114,9 +128,13 @@ exports.typeDefs = `
     createLayout(layout: LayoutInput): Layout @beehiveCreate(target_type_name: "Layout")
     # set the end date for a Layout
     updateLayout(layout_id: ID!, layout: AssignmentUpdateInput): Layout @beehiveUpdate(target_type_name: "Layout")
-    
-    # Create a new Person
+
+    # Create a new person
     createPerson(person: PersonInput): Person @beehiveCreate(target_type_name: "Person")
+    # Update a person
+    updatePerson(person_id: ID!, person: PersonInput): Environment @beehiveUpdate(target_type_name: "Person")
+    # Delete a person
+    deletePerson(person_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Person")
   }
 
 `

--- a/src/schema/environments.js
+++ b/src/schema/environments.js
@@ -109,7 +109,7 @@ exports.typeDefs = `
     persons(page: PaginationInput): PersonList @beehiveList(target_type_name: "Person")
     # Get a person
     getPerson(person_id: ID!): Person @beehiveGet(target_type_name: "Person")
-    # Find a person based on one or more of their properties
+    # Find people based on one or more of their properties
     findPersons(name: String): PersonList @beehiveSimpleQuery(target_type_name: "Person")
     # Find people using a complex query
     searchPersons(query: QueryExpression!, page: PaginationInput): PersonList @beehiveQuery(target_type_name: "Person")
@@ -132,7 +132,7 @@ exports.typeDefs = `
     # Create a new person
     createPerson(person: PersonInput): Person @beehiveCreate(target_type_name: "Person")
     # Update a person
-    updatePerson(person_id: ID!, person: PersonInput): Environment @beehiveUpdate(target_type_name: "Person")
+    updatePerson(person_id: ID!, person: PersonInput): Person @beehiveUpdate(target_type_name: "Person")
     # Delete a person
     deletePerson(person_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Person")
   }

--- a/src/schema/environments.js
+++ b/src/schema/environments.js
@@ -81,8 +81,18 @@ exports.typeDefs = `
     location: String
   }
 
+  input EnvironmentUpdateInput {
+    name: String
+    description: String
+    location: String
+  }
+
   input PersonInput {
     name: String!
+  }
+
+  input PersonUpdateInput {
+    name: String
   }
 
   input AssignmentInput {
@@ -123,7 +133,7 @@ exports.typeDefs = `
     # Create a new environment
     createEnvironment(environment: EnvironmentInput): Environment @beehiveCreate(target_type_name: "Environment")
     # Update a person
-    updateEnvironment(environment_id: ID!, environment: EnvironmentInput): Environment @beehiveUpdate(target_type_name: "Environment")
+    updateEnvironment(environment_id: ID!, environment: EnvironmentUpdateInput): Environment @beehiveUpdate(target_type_name: "Environment")
     # Delete an environment
     deleteEnvironment(environment_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Environment")
 
@@ -140,7 +150,7 @@ exports.typeDefs = `
     # Create a new person
     createPerson(person: PersonInput): Person @beehiveCreate(target_type_name: "Person")
     # Update a person
-    updatePerson(person_id: ID!, person: PersonInput): Person @beehiveUpdate(target_type_name: "Person")
+    updatePerson(person_id: ID!, person: PersonUpdateInput): Person @beehiveUpdate(target_type_name: "Person")
     # Delete a person
     deletePerson(person_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Person")
   }

--- a/src/schema/sensors.js
+++ b/src/schema/sensors.js
@@ -93,6 +93,15 @@ exports.typeDefs = `
     mac_address: [String!]
   }
 
+  input DeviceUpdateInput {
+    name: String
+    description: String
+    part_number: String
+    tag_id: String
+    serial_number: String
+    mac_address: [String!]
+  }
+
   input SensorInstallationInput {
     device: ID!
     sensor: ID!
@@ -149,7 +158,7 @@ exports.typeDefs = `
     # Create a new device
     createDevice(device: DeviceInput): Device @beehiveCreate(target_type_name: "Device")
     # Update a device
-    updateDevice(device_id: ID!, device: DeviceInput): Device @beehiveUpdate(target_type_name: "Device")
+    updateDevice(device_id: ID!, device: DeviceUpdateInput): Device @beehiveUpdate(target_type_name: "Device")
     # Delete a device
     deleteDevice(device_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Device")
 

--- a/src/schema/sensors.js
+++ b/src/schema/sensors.js
@@ -121,12 +121,18 @@ exports.typeDefs = `
   }
 
   extend type Query {
-    # Gets the list of devices
-    devices(envId: String, page: PaginationInput): DeviceList! @beehiveList(target_type_name: "Device")
+    # Get the list of devices (use of envID argument is DEPRECATED)
+    devices(envId: String, page: PaginationInput): DeviceList @beehiveList(target_type_name: "Device")
     # Get a device
+    getDevice(device_id: ID!): Device @beehiveGet(target_type_name: "Device")
+    # Get a device (DEPRECATED; use getDevice instead)
     device(device_id: ID): Device @beehiveGet(target_type_name: "Device")
-    # Find a device based on one or more of it's properties
+    # Find devices based on one or more of their properties
+    findDevices(part_number: String, name: String, tag_id: String, serial_number: String, page: PaginationInput): DeviceList @beehiveSimpleQuery(target_type_name: "Device")
+    # Find devices based on one or more of their properties (DEPRECATED; use findDevices instead)
     findDevice(name: String, part_number: String): DeviceList! @beehiveSimpleQuery(target_type_name: "Device")
+    # Find devices using a complex query
+    searchDevices(query: QueryExpression!, page: PaginationInput): DeviceList @beehiveQuery(target_type_name: "Device")
 
     # Gets the list of sensors
     sensors(page: PaginationInput): SensorList! @beehiveList(target_type_name: "Sensor")
@@ -140,10 +146,13 @@ exports.typeDefs = `
   }
 
   extend type Mutation {
-    # adds a new device to the graph
+    # Create a new device
     createDevice(device: DeviceInput): Device @beehiveCreate(target_type_name: "Device")
-    # update an existing device
+    # Update a device
     updateDevice(device_id: ID!, device: DeviceInput): Device @beehiveUpdate(target_type_name: "Device")
+    # Delete a device
+    deleteDevice(device_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Device")
+
     # sets the device configuration
     setDeviceConfiguration(deviceConfiguration: DeviceConfigurationInput): DeviceConfiguration @beehiveCreate(target_type_name: "DeviceConfiguration")
     # adds a new sensor to the graph


### PR DESCRIPTION
Created a consistent set of endpoints (`createObject`, `objects`, `getObject`, `findObjects`, `searchObjects` ,`updateObject`,  `deleteObject`) for the most common objects (`Environment`, `Device`, `Person`, `InferenceExecution`, `Material`, `Datapoint`)

Note:
* I consistently made the names of the `findObjects` endpoints plural, to reflect the fact that they return lists
* I omitted `findDatapoints`, because there were no obvious input type fields to find on
* I omitted the `file` field from `updateDatapoint` because I wasn't sure how that should interact with S3
* I have retained current alternative versions of these endpoints wherever possible, but marked them as `DEPRECATED` in the comment-level descriptions (is there somewhere else I can/should mark them as deprecated?)
* One exception is `materials`, which had been defined as a complex query. It is now a simple list pull (like the other objects). I think this is OK because I don't think anybody was using this endpoint.
