### PR TITLE
Expand pose objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -938,9 +938,9 @@
                     "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
                     "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
                     "requires": {
-                        "@types/body-parser": "*",
-                        "@types/express-serve-static-core": "*",
-                        "@types/serve-static": "*"
+                        "@types/body-parser": "1.17.1",
+                        "@types/express-serve-static-core": "4.17.0",
+                        "@types/serve-static": "1.13.3"
                     }
                 },
                 "apollo": {
@@ -1008,11 +1008,11 @@
                     "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.9.13.tgz",
                     "integrity": "sha512-Aedj/aHRMCDMUwtM+hXiliX1OkFNl1NyiQUADbwm6AMV3OrfT9TUbbSI1AN2qsx+rg6dIhpAiHLUf73uDy3V/g==",
                     "requires": {
-                        "apollo-server-core": "^2.9.13",
-                        "apollo-server-express": "^2.9.13",
-                        "express": "^4.0.0",
-                        "graphql-subscriptions": "^1.0.0",
-                        "graphql-tools": "^4.0.0"
+                        "apollo-server-core": "2.9.13",
+                        "apollo-server-express": "2.9.13",
+                        "express": "4.17.1",
+                        "graphql-subscriptions": "1.1.0",
+                        "graphql-tools": "4.0.6"
                     }
                 },
                 "apollo-server-express": {
@@ -1021,21 +1021,21 @@
                     "integrity": "sha512-M306e07dpZ8YpZx4VBYa0FWlt+wopj4Bwn0Iy1iJ6VjaRyGx2HCUJvLpHZ+D0TIXtQ2nX3DTYeOouVaDDwJeqQ==",
                     "requires": {
                         "@apollographql/graphql-playground-html": "1.6.24",
-                        "@types/accepts": "^1.3.5",
+                        "@types/accepts": "1.3.5",
                         "@types/body-parser": "1.17.1",
-                        "@types/cors": "^2.8.4",
+                        "@types/cors": "2.8.6",
                         "@types/express": "4.17.1",
-                        "accepts": "^1.3.5",
-                        "apollo-server-core": "^2.9.13",
-                        "apollo-server-types": "^0.2.8",
-                        "body-parser": "^1.18.3",
-                        "cors": "^2.8.4",
-                        "express": "^4.17.1",
-                        "graphql-subscriptions": "^1.0.0",
-                        "graphql-tools": "^4.0.0",
-                        "parseurl": "^1.3.2",
-                        "subscriptions-transport-ws": "^0.9.16",
-                        "type-is": "^1.6.16"
+                        "accepts": "1.3.7",
+                        "apollo-server-core": "2.9.13",
+                        "apollo-server-types": "0.2.8",
+                        "body-parser": "1.19.0",
+                        "cors": "2.8.5",
+                        "express": "4.17.1",
+                        "graphql-subscriptions": "1.1.0",
+                        "graphql-tools": "4.0.6",
+                        "parseurl": "1.3.3",
+                        "subscriptions-transport-ws": "0.9.16",
+                        "type-is": "1.6.18"
                     }
                 },
                 "indent-string": {
@@ -1903,11 +1903,11 @@
             "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.14.2.tgz",
             "integrity": "sha512-H+X3HprWGxV8DIhQyXzheMheKRxSlD9/lMuzIHyW/7VPspc7rX0xsHaFcTwQGcxLz18LhM+HtMBtvzi/KlRIbA==",
             "requires": {
-                "apollo-server-core": "^2.14.2",
-                "apollo-server-express": "^2.14.2",
-                "express": "^4.0.0",
-                "graphql-subscriptions": "^1.0.0",
-                "graphql-tools": "^4.0.0"
+                "apollo-server-core": "2.14.2",
+                "apollo-server-express": "2.14.2",
+                "express": "4.17.1",
+                "graphql-subscriptions": "1.1.0",
+                "graphql-tools": "4.0.6"
             },
             "dependencies": {
                 "@apollographql/apollo-tools": {
@@ -1915,7 +1915,7 @@
                     "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
                     "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
                     "requires": {
-                        "apollo-env": "^0.6.5"
+                        "apollo-env": "0.6.5"
                     }
                 },
                 "@types/body-parser": {
@@ -1923,8 +1923,8 @@
                     "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
                     "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
                     "requires": {
-                        "@types/connect": "*",
-                        "@types/node": "*"
+                        "@types/connect": "3.4.32",
+                        "@types/node": "12.12.17"
                     }
                 },
                 "@types/express": {
@@ -1932,10 +1932,10 @@
                     "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.4.tgz",
                     "integrity": "sha512-DO1L53rGqIDUEvOjJKmbMEQ5Z+BM2cIEPy/eV3En+s166Gz+FeuzRerxcab757u/U4v4XF4RYrZPmqKa+aY/2w==",
                     "requires": {
-                        "@types/body-parser": "*",
-                        "@types/express-serve-static-core": "*",
-                        "@types/qs": "*",
-                        "@types/serve-static": "*"
+                        "@types/body-parser": "1.19.0",
+                        "@types/express-serve-static-core": "4.17.0",
+                        "@types/qs": "6.9.3",
+                        "@types/serve-static": "1.13.3"
                     }
                 },
                 "@types/node-fetch": {
@@ -1943,8 +1943,8 @@
                     "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
                     "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
                     "requires": {
-                        "@types/node": "*",
-                        "form-data": "^3.0.0"
+                        "@types/node": "12.12.17",
+                        "form-data": "3.0.0"
                     }
                 },
                 "@types/ws": {
@@ -1952,7 +1952,7 @@
                     "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
                     "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
                     "requires": {
-                        "@types/node": "*"
+                        "@types/node": "12.12.17"
                     }
                 },
                 "apollo-cache-control": {
@@ -1960,8 +1960,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.0.tgz",
                     "integrity": "sha512-dmRnQ9AXGw2SHahVGLzB/p4UW/taFBAJxifxubp8hqY5p9qdlSu4MPRq8zvV2ULMYf50rBtZyC4C+dZLqmHuHQ==",
                     "requires": {
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-plugin-base": "^0.9.0"
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-plugin-base": "0.9.0"
                     }
                 },
                 "apollo-datasource": {
@@ -1969,8 +1969,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.1.tgz",
                     "integrity": "sha512-h++/jQAY7GA+4TBM+7ezvctFmmGNLrAPf51KsagZj+NkT9qvxp585rdsuatynVbSl59toPK2EuVmc6ilmQHf+g==",
                     "requires": {
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4"
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4"
                     }
                 },
                 "apollo-engine-reporting": {
@@ -1978,15 +1978,15 @@
                     "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-2.0.0.tgz",
                     "integrity": "sha512-FvNwORsh3nxEfvQqd2xbd468a0q/R3kYar/Bk6YQdBX5qwqUhqmOcOSxLFk8Zb77HpwHij5CPpPWJb53TU1zcA==",
                     "requires": {
-                        "apollo-engine-reporting-protobuf": "^0.5.1",
-                        "apollo-graphql": "^0.4.0",
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-errors": "^2.4.1",
-                        "apollo-server-plugin-base": "^0.9.0",
-                        "apollo-server-types": "^0.5.0",
-                        "async-retry": "^1.2.1",
-                        "uuid": "^8.0.0"
+                        "apollo-engine-reporting-protobuf": "0.5.1",
+                        "apollo-graphql": "0.4.4",
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-errors": "2.4.1",
+                        "apollo-server-plugin-base": "0.9.0",
+                        "apollo-server-types": "0.5.0",
+                        "async-retry": "1.2.3",
+                        "uuid": "8.1.0"
                     }
                 },
                 "apollo-engine-reporting-protobuf": {
@@ -1994,7 +1994,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.1.tgz",
                     "integrity": "sha512-TSfr9iAaInV8dhXkesdcmqsthRkVcJkzznmiM+1Ob/GScK7r6hBYCjVDt2613EHAg9SUzTOltIKlGD+N+GJRUw==",
                     "requires": {
-                        "@apollo/protobufjs": "^1.0.3"
+                        "@apollo/protobufjs": "1.0.3"
                     }
                 },
                 "apollo-env": {
@@ -2003,9 +2003,9 @@
                     "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
                     "requires": {
                         "@types/node-fetch": "2.5.7",
-                        "core-js": "^3.0.1",
-                        "node-fetch": "^2.2.0",
-                        "sha.js": "^2.4.11"
+                        "core-js": "3.5.0",
+                        "node-fetch": "2.6.0",
+                        "sha.js": "2.4.11"
                     }
                 },
                 "apollo-graphql": {
@@ -2013,8 +2013,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.4.tgz",
                     "integrity": "sha512-i012iRKT5nfsOaNMx4MTwHw2jrlyaF1zikpejxsGHsKIf3OngGvGh3pyw20bEmwj413OrNQpRxvvIz5A7W/8xw==",
                     "requires": {
-                        "apollo-env": "^0.6.5",
-                        "lodash.sortby": "^4.7.0"
+                        "apollo-env": "0.6.5",
+                        "lodash.sortby": "4.7.0"
                     }
                 },
                 "apollo-server-caching": {
@@ -2022,7 +2022,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
                     "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
                     "requires": {
-                        "lru-cache": "^5.0.0"
+                        "lru-cache": "5.1.1"
                     }
                 },
                 "apollo-server-core": {
@@ -2030,28 +2030,28 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.2.tgz",
                     "integrity": "sha512-8G6Aoz+k+ecuQco1KNLFbMrxhe/8uR4AOaOYEvT/N5m/6lrkPYzvBAxbpRIub5AxEwpBPcIrI452rR3PD9DItA==",
                     "requires": {
-                        "@apollographql/apollo-tools": "^0.4.3",
+                        "@apollographql/apollo-tools": "0.4.8",
                         "@apollographql/graphql-playground-html": "1.6.24",
-                        "@types/graphql-upload": "^8.0.0",
-                        "@types/ws": "^7.0.0",
-                        "apollo-cache-control": "^0.11.0",
-                        "apollo-datasource": "^0.7.1",
-                        "apollo-engine-reporting": "^2.0.0",
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-errors": "^2.4.1",
-                        "apollo-server-plugin-base": "^0.9.0",
-                        "apollo-server-types": "^0.5.0",
-                        "apollo-tracing": "^0.11.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graphql-extensions": "^0.12.2",
-                        "graphql-tag": "^2.9.2",
-                        "graphql-tools": "^4.0.0",
-                        "graphql-upload": "^8.0.2",
-                        "loglevel": "^1.6.7",
-                        "sha.js": "^2.4.11",
-                        "subscriptions-transport-ws": "^0.9.11",
-                        "ws": "^6.0.0"
+                        "@types/graphql-upload": "8.0.3",
+                        "@types/ws": "7.2.5",
+                        "apollo-cache-control": "0.11.0",
+                        "apollo-datasource": "0.7.1",
+                        "apollo-engine-reporting": "2.0.0",
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-errors": "2.4.1",
+                        "apollo-server-plugin-base": "0.9.0",
+                        "apollo-server-types": "0.5.0",
+                        "apollo-tracing": "0.11.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graphql-extensions": "0.12.2",
+                        "graphql-tag": "2.10.1",
+                        "graphql-tools": "4.0.6",
+                        "graphql-upload": "8.1.0",
+                        "loglevel": "1.6.8",
+                        "sha.js": "2.4.11",
+                        "subscriptions-transport-ws": "0.9.16",
+                        "ws": "6.2.1"
                     }
                 },
                 "apollo-server-env": {
@@ -2059,8 +2059,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.4.tgz",
                     "integrity": "sha512-c2oddDS3lwAl6QNCIKCLEzt/dF9M3/tjjYRVdxOVN20TidybI7rAbnT4QOzf4tORnGXtiznEAvr/Kc9ahhKADg==",
                     "requires": {
-                        "node-fetch": "^2.1.2",
-                        "util.promisify": "^1.0.0"
+                        "node-fetch": "2.6.0",
+                        "util.promisify": "1.0.0"
                     }
                 },
                 "apollo-server-errors": {
@@ -2074,21 +2074,21 @@
                     "integrity": "sha512-iYyZm0kQqkM561i9l0WC9HbJsGZJbHP9bhnWaa1Itd+yNBS2AJFp6mRR3hQacsWXUw7ewaKAracMIggvfSH5Aw==",
                     "requires": {
                         "@apollographql/graphql-playground-html": "1.6.24",
-                        "@types/accepts": "^1.3.5",
+                        "@types/accepts": "1.3.5",
                         "@types/body-parser": "1.19.0",
-                        "@types/cors": "^2.8.4",
+                        "@types/cors": "2.8.6",
                         "@types/express": "4.17.4",
-                        "accepts": "^1.3.5",
-                        "apollo-server-core": "^2.14.2",
-                        "apollo-server-types": "^0.5.0",
-                        "body-parser": "^1.18.3",
-                        "cors": "^2.8.4",
-                        "express": "^4.17.1",
-                        "graphql-subscriptions": "^1.0.0",
-                        "graphql-tools": "^4.0.0",
-                        "parseurl": "^1.3.2",
-                        "subscriptions-transport-ws": "^0.9.16",
-                        "type-is": "^1.6.16"
+                        "accepts": "1.3.7",
+                        "apollo-server-core": "2.14.2",
+                        "apollo-server-types": "0.5.0",
+                        "body-parser": "1.19.0",
+                        "cors": "2.8.5",
+                        "express": "4.17.1",
+                        "graphql-subscriptions": "1.1.0",
+                        "graphql-tools": "4.0.6",
+                        "parseurl": "1.3.3",
+                        "subscriptions-transport-ws": "0.9.16",
+                        "type-is": "1.6.18"
                     }
                 },
                 "apollo-server-plugin-base": {
@@ -2096,7 +2096,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.0.tgz",
                     "integrity": "sha512-LWcPrsy2+xqwlNseh/QaGa/MPNopS8c4qGgh0g0cAn0lZBRrJ9Yab7dq+iQ6vdUBwIhUWYN6s9dwUWCZw2SL8g==",
                     "requires": {
-                        "apollo-server-types": "^0.5.0"
+                        "apollo-server-types": "0.5.0"
                     }
                 },
                 "apollo-server-types": {
@@ -2104,9 +2104,9 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
                     "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
                     "requires": {
-                        "apollo-engine-reporting-protobuf": "^0.5.1",
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4"
+                        "apollo-engine-reporting-protobuf": "0.5.1",
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4"
                     }
                 },
                 "apollo-tracing": {
@@ -2114,8 +2114,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.11.0.tgz",
                     "integrity": "sha512-I9IFb/8lkBW8ZwOAi4LEojfT7dMfUSkpnV8LHQI8Rcj0HtzL9HObQ3woBmzyGHdGHLFuD/6/VHyFD67SesSrJg==",
                     "requires": {
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-plugin-base": "^0.9.0"
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-plugin-base": "0.9.0"
                     }
                 },
                 "form-data": {
@@ -2123,9 +2123,9 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
                     "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
                     "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.8",
+                        "mime-types": "2.1.25"
                     }
                 },
                 "graphql-extensions": {
@@ -2133,9 +2133,9 @@
                     "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.2.tgz",
                     "integrity": "sha512-vFaZua5aLiCOOzxfY5qzHZ6S52BCqW7VVOwzvV52Wb5edRm3dn6u+1MR9yYyEqUHSf8LvdhEojYlOkKiaQ4ghA==",
                     "requires": {
-                        "@apollographql/apollo-tools": "^0.4.3",
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-types": "^0.5.0"
+                        "@apollographql/apollo-tools": "0.4.8",
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-types": "0.5.0"
                     }
                 },
                 "node-fetch": {
@@ -2213,21 +2213,21 @@
             "integrity": "sha512-iYyZm0kQqkM561i9l0WC9HbJsGZJbHP9bhnWaa1Itd+yNBS2AJFp6mRR3hQacsWXUw7ewaKAracMIggvfSH5Aw==",
             "requires": {
                 "@apollographql/graphql-playground-html": "1.6.24",
-                "@types/accepts": "^1.3.5",
+                "@types/accepts": "1.3.5",
                 "@types/body-parser": "1.19.0",
-                "@types/cors": "^2.8.4",
+                "@types/cors": "2.8.6",
                 "@types/express": "4.17.4",
-                "accepts": "^1.3.5",
-                "apollo-server-core": "^2.14.2",
-                "apollo-server-types": "^0.5.0",
-                "body-parser": "^1.18.3",
-                "cors": "^2.8.4",
-                "express": "^4.17.1",
-                "graphql-subscriptions": "^1.0.0",
-                "graphql-tools": "^4.0.0",
-                "parseurl": "^1.3.2",
-                "subscriptions-transport-ws": "^0.9.16",
-                "type-is": "^1.6.16"
+                "accepts": "1.3.7",
+                "apollo-server-core": "2.14.3",
+                "apollo-server-types": "0.5.0",
+                "body-parser": "1.19.0",
+                "cors": "2.8.5",
+                "express": "4.17.1",
+                "graphql-subscriptions": "1.1.0",
+                "graphql-tools": "4.0.6",
+                "parseurl": "1.3.3",
+                "subscriptions-transport-ws": "0.9.16",
+                "type-is": "1.6.18"
             },
             "dependencies": {
                 "@apollographql/apollo-tools": {
@@ -2235,7 +2235,7 @@
                     "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
                     "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
                     "requires": {
-                        "apollo-env": "^0.6.5"
+                        "apollo-env": "0.6.5"
                     }
                 },
                 "@types/body-parser": {
@@ -2243,8 +2243,8 @@
                     "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
                     "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
                     "requires": {
-                        "@types/connect": "*",
-                        "@types/node": "*"
+                        "@types/connect": "3.4.32",
+                        "@types/node": "12.12.17"
                     }
                 },
                 "@types/express": {
@@ -2252,10 +2252,10 @@
                     "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.4.tgz",
                     "integrity": "sha512-DO1L53rGqIDUEvOjJKmbMEQ5Z+BM2cIEPy/eV3En+s166Gz+FeuzRerxcab757u/U4v4XF4RYrZPmqKa+aY/2w==",
                     "requires": {
-                        "@types/body-parser": "*",
-                        "@types/express-serve-static-core": "*",
-                        "@types/qs": "*",
-                        "@types/serve-static": "*"
+                        "@types/body-parser": "1.19.0",
+                        "@types/express-serve-static-core": "4.17.0",
+                        "@types/qs": "6.9.3",
+                        "@types/serve-static": "1.13.3"
                     }
                 },
                 "@types/node-fetch": {
@@ -2263,8 +2263,8 @@
                     "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
                     "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
                     "requires": {
-                        "@types/node": "*",
-                        "form-data": "^3.0.0"
+                        "@types/node": "12.12.17",
+                        "form-data": "3.0.0"
                     }
                 },
                 "@types/ws": {
@@ -2272,7 +2272,7 @@
                     "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
                     "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
                     "requires": {
-                        "@types/node": "*"
+                        "@types/node": "12.12.17"
                     }
                 },
                 "apollo-cache-control": {
@@ -2280,8 +2280,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.0.tgz",
                     "integrity": "sha512-dmRnQ9AXGw2SHahVGLzB/p4UW/taFBAJxifxubp8hqY5p9qdlSu4MPRq8zvV2ULMYf50rBtZyC4C+dZLqmHuHQ==",
                     "requires": {
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-plugin-base": "^0.9.0"
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-plugin-base": "0.9.0"
                     }
                 },
                 "apollo-datasource": {
@@ -2289,8 +2289,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.1.tgz",
                     "integrity": "sha512-h++/jQAY7GA+4TBM+7ezvctFmmGNLrAPf51KsagZj+NkT9qvxp585rdsuatynVbSl59toPK2EuVmc6ilmQHf+g==",
                     "requires": {
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4"
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4"
                     }
                 },
                 "apollo-engine-reporting": {
@@ -2298,15 +2298,15 @@
                     "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-2.0.0.tgz",
                     "integrity": "sha512-FvNwORsh3nxEfvQqd2xbd468a0q/R3kYar/Bk6YQdBX5qwqUhqmOcOSxLFk8Zb77HpwHij5CPpPWJb53TU1zcA==",
                     "requires": {
-                        "apollo-engine-reporting-protobuf": "^0.5.1",
-                        "apollo-graphql": "^0.4.0",
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-errors": "^2.4.1",
-                        "apollo-server-plugin-base": "^0.9.0",
-                        "apollo-server-types": "^0.5.0",
-                        "async-retry": "^1.2.1",
-                        "uuid": "^8.0.0"
+                        "apollo-engine-reporting-protobuf": "0.5.1",
+                        "apollo-graphql": "0.4.5",
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-errors": "2.4.1",
+                        "apollo-server-plugin-base": "0.9.0",
+                        "apollo-server-types": "0.5.0",
+                        "async-retry": "1.2.3",
+                        "uuid": "8.1.0"
                     }
                 },
                 "apollo-engine-reporting-protobuf": {
@@ -2314,7 +2314,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.1.tgz",
                     "integrity": "sha512-TSfr9iAaInV8dhXkesdcmqsthRkVcJkzznmiM+1Ob/GScK7r6hBYCjVDt2613EHAg9SUzTOltIKlGD+N+GJRUw==",
                     "requires": {
-                        "@apollo/protobufjs": "^1.0.3"
+                        "@apollo/protobufjs": "1.0.3"
                     }
                 },
                 "apollo-env": {
@@ -2323,9 +2323,9 @@
                     "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
                     "requires": {
                         "@types/node-fetch": "2.5.7",
-                        "core-js": "^3.0.1",
-                        "node-fetch": "^2.2.0",
-                        "sha.js": "^2.4.11"
+                        "core-js": "3.5.0",
+                        "node-fetch": "2.6.0",
+                        "sha.js": "2.4.11"
                     }
                 },
                 "apollo-graphql": {
@@ -2333,8 +2333,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.5.tgz",
                     "integrity": "sha512-0qa7UOoq7E71kBYE7idi6mNQhHLVdMEDInWk6TNw3KsSWZE2/I68gARP84Mj+paFTO5NYuw1Dht66PVX76Cc2w==",
                     "requires": {
-                        "apollo-env": "^0.6.5",
-                        "lodash.sortby": "^4.7.0"
+                        "apollo-env": "0.6.5",
+                        "lodash.sortby": "4.7.0"
                     }
                 },
                 "apollo-server-caching": {
@@ -2342,7 +2342,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
                     "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
                     "requires": {
-                        "lru-cache": "^5.0.0"
+                        "lru-cache": "5.1.1"
                     }
                 },
                 "apollo-server-core": {
@@ -2350,28 +2350,28 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.3.tgz",
                     "integrity": "sha512-A9RkWuHFZ04uEnXof5V02T7wfhUel7Hx9LpEN4N59mXTpb7ewW+cb0u+J+SP+Y4vDhVqaHCGoveRVKy6X2kLhw==",
                     "requires": {
-                        "@apollographql/apollo-tools": "^0.4.3",
+                        "@apollographql/apollo-tools": "0.4.8",
                         "@apollographql/graphql-playground-html": "1.6.24",
-                        "@types/graphql-upload": "^8.0.0",
-                        "@types/ws": "^7.0.0",
-                        "apollo-cache-control": "^0.11.0",
-                        "apollo-datasource": "^0.7.1",
-                        "apollo-engine-reporting": "^2.0.0",
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-errors": "^2.4.1",
-                        "apollo-server-plugin-base": "^0.9.0",
-                        "apollo-server-types": "^0.5.0",
-                        "apollo-tracing": "^0.11.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graphql-extensions": "^0.12.2",
-                        "graphql-tag": "^2.9.2",
-                        "graphql-tools": "^4.0.0",
-                        "graphql-upload": "^8.0.2",
-                        "loglevel": "^1.6.7",
-                        "sha.js": "^2.4.11",
-                        "subscriptions-transport-ws": "^0.9.11",
-                        "ws": "^6.0.0"
+                        "@types/graphql-upload": "8.0.3",
+                        "@types/ws": "7.2.5",
+                        "apollo-cache-control": "0.11.0",
+                        "apollo-datasource": "0.7.1",
+                        "apollo-engine-reporting": "2.0.0",
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-errors": "2.4.1",
+                        "apollo-server-plugin-base": "0.9.0",
+                        "apollo-server-types": "0.5.0",
+                        "apollo-tracing": "0.11.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graphql-extensions": "0.12.2",
+                        "graphql-tag": "2.10.1",
+                        "graphql-tools": "4.0.6",
+                        "graphql-upload": "8.1.0",
+                        "loglevel": "1.6.8",
+                        "sha.js": "2.4.11",
+                        "subscriptions-transport-ws": "0.9.16",
+                        "ws": "6.2.1"
                     }
                 },
                 "apollo-server-env": {
@@ -2379,8 +2379,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.4.tgz",
                     "integrity": "sha512-c2oddDS3lwAl6QNCIKCLEzt/dF9M3/tjjYRVdxOVN20TidybI7rAbnT4QOzf4tORnGXtiznEAvr/Kc9ahhKADg==",
                     "requires": {
-                        "node-fetch": "^2.1.2",
-                        "util.promisify": "^1.0.0"
+                        "node-fetch": "2.6.0",
+                        "util.promisify": "1.0.0"
                     }
                 },
                 "apollo-server-errors": {
@@ -2393,7 +2393,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.0.tgz",
                     "integrity": "sha512-LWcPrsy2+xqwlNseh/QaGa/MPNopS8c4qGgh0g0cAn0lZBRrJ9Yab7dq+iQ6vdUBwIhUWYN6s9dwUWCZw2SL8g==",
                     "requires": {
-                        "apollo-server-types": "^0.5.0"
+                        "apollo-server-types": "0.5.0"
                     }
                 },
                 "apollo-server-types": {
@@ -2401,9 +2401,9 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
                     "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
                     "requires": {
-                        "apollo-engine-reporting-protobuf": "^0.5.1",
-                        "apollo-server-caching": "^0.5.1",
-                        "apollo-server-env": "^2.4.4"
+                        "apollo-engine-reporting-protobuf": "0.5.1",
+                        "apollo-server-caching": "0.5.1",
+                        "apollo-server-env": "2.4.4"
                     }
                 },
                 "apollo-tracing": {
@@ -2411,8 +2411,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.11.0.tgz",
                     "integrity": "sha512-I9IFb/8lkBW8ZwOAi4LEojfT7dMfUSkpnV8LHQI8Rcj0HtzL9HObQ3woBmzyGHdGHLFuD/6/VHyFD67SesSrJg==",
                     "requires": {
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-plugin-base": "^0.9.0"
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-plugin-base": "0.9.0"
                     }
                 },
                 "form-data": {
@@ -2420,9 +2420,9 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
                     "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
                     "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.8",
+                        "mime-types": "2.1.25"
                     }
                 },
                 "graphql-extensions": {
@@ -2430,9 +2430,9 @@
                     "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.2.tgz",
                     "integrity": "sha512-vFaZua5aLiCOOzxfY5qzHZ6S52BCqW7VVOwzvV52Wb5edRm3dn6u+1MR9yYyEqUHSf8LvdhEojYlOkKiaQ4ghA==",
                     "requires": {
-                        "@apollographql/apollo-tools": "^0.4.3",
-                        "apollo-server-env": "^2.4.4",
-                        "apollo-server-types": "^0.5.0"
+                        "@apollographql/apollo-tools": "0.4.8",
+                        "apollo-server-env": "2.4.4",
+                        "apollo-server-types": "0.5.0"
                     }
                 },
                 "node-fetch": {

--- a/src/schema/data.js
+++ b/src/schema/data.js
@@ -227,6 +227,36 @@ input Pose3DInput {
     datapoint: ID
 }
 
+type PoseTrack3D @beehiveTable(
+    table_name: "posetracks3d",
+    pk_column: "pose_track_id",
+    table_type: native,
+    native_indexes: [
+        {name: "created", type: btree, columns: ["created"]},
+    ]
+) {
+    pose_track_id: ID!
+    # 3D poses that are part of this track
+    poses_3d: [String]
+    # Label of track assigned by pose tracking inference
+    track_label: String
+    # where did the data originate
+    source: SourceObject @beehiveUnionResolver(target_types: ["Assignment", "Person", "InferenceExecution", "Environment"])
+    source_type: DataSourceType
+}
+
+type PoseTrack3DList{
+    data: [PoseTrack3D!]
+    page_info: PageInfo!
+}
+
+input PoseTrack3DInput {
+    poses_3d: [ID]
+    track_label: String
+    source: ID
+    source_type: DataSourceType
+}
+
 type Pose2D @beehiveTable(
     table_name: "poses2d",
     pk_column: "pose_id",
@@ -363,6 +393,13 @@ extend type Query {
     # Find 3D poses using a complex query
     searchPoses3D(query: QueryExpression!, page: PaginationInput): Pose3DList @beehiveQuery(target_type_name: "Pose3D")
 
+    # Get the list of 3D pose tracks
+    poseTracks3D(page: PaginationInput): PoseTrack3DList @beehiveList(target_type_name: "PoseTrack3D")
+    # Get a 3D pose track
+    getPoseTrack3D(pose_track_id: ID!): PoseTrack3D @beehiveGet(target_type_name: "PoseTrack3D")
+    # Find 3D pose tracks using a complex query
+    searchPoseTracks3D(query: QueryExpression!, page: PaginationInput): PoseTrack3DList @beehiveQuery(target_type_name: "PoseTrack3D")
+
     # Get the list of 2D poses
     poses2D(page: PaginationInput): Pose2DList @beehiveList(target_type_name: "Pose2D")
     # Get a 2D pose
@@ -400,6 +437,11 @@ extend type Mutation {
     createPose3D(pose3D: Pose3DInput): Pose3D @beehiveCreate(target_type_name: "Pose3D")
     # Delete a 3D pose
     deletePose3D(pose_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Pose3D")
+
+    # Create a new 3D pose track
+    createPoseTrack3D(poseTrack3D: PoseTrack3DInput): PoseTrack3D @beehiveCreate(target_type_name: "PoseTrack3D")
+    # Delete a 3D pose track
+    deletePoseTrack3D(pose_track_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "PoseTrack3D")
 
     # Create a new 2D pose
     createPose2D(pose2D: Pose2DInput): Pose2D @beehiveCreate(target_type_name: "Pose2D")

--- a/src/schema/data.js
+++ b/src/schema/data.js
@@ -198,6 +198,8 @@ type Pose3D @beehiveTable(
     person: Person @beehiveRelation(target_type_name: "Person")
     # duration of the data included in this observation. time should be expressed in milliseconds. If not set then assumed to be a snapshot observation without a duration
     duration: Int
+    # 2D poses that inform this 3D pose
+    poses_2d: [String]
     # where did the data originate
     source: SourceObject @beehiveUnionResolver(target_types: ["Assignment", "Person", "InferenceExecution", "Environment"])
     source_type: DataSourceType
@@ -221,6 +223,7 @@ input Pose3DInput {
     quality: Float
     person: ID
     duration: Int
+    poses_2d: [String]
     source: ID
     source_type: DataSourceType
     tags: [String!]

--- a/src/schema/data.js
+++ b/src/schema/data.js
@@ -318,6 +318,36 @@ input Pose2DInput {
     datapoint: ID
 }
 
+type PoseTrack2D @beehiveTable(
+    table_name: "posetracks2d",
+    pk_column: "pose_track_id",
+    table_type: native,
+    native_indexes: [
+        {name: "created", type: btree, columns: ["created"]},
+    ]
+) {
+    pose_track_id: ID!
+    # 2D poses that are part of this track
+    poses_2d: [String]
+    # Label of track assigned by pose tracking inference
+    track_label: String
+    # where did the data originate
+    source: SourceObject @beehiveUnionResolver(target_types: ["Assignment", "Person", "InferenceExecution", "Environment"])
+    source_type: DataSourceType
+}
+
+type PoseTrack2DList{
+    data: [PoseTrack2D!]
+    page_info: PageInfo!
+}
+
+input PoseTrack2DInput {
+    poses_2d: [ID]
+    track_label: String
+    source: ID
+    source_type: DataSourceType
+}
+
 enum DataSourceType {
     GROUND_TRUTH
     GENERATED_TEST
@@ -407,6 +437,13 @@ extend type Query {
     # Find 2D poses using a complex query
     searchPoses2D(query: QueryExpression!, page: PaginationInput): Pose2DList @beehiveQuery(target_type_name: "Pose2D")
 
+    # Get the list of 2D pose tracks
+    poseTracks2D(page: PaginationInput): PoseTrack2DList @beehiveList(target_type_name: "PoseTrack2D")
+    # Get a 2D pose track
+    getPoseTrack2D(pose_track_id: ID!): PoseTrack2D @beehiveGet(target_type_name: "PoseTrack2D")
+    # Find 2D pose tracks using a complex query
+    searchPoseTracks2D(query: QueryExpression!, page: PaginationInput): PoseTrack2DList @beehiveQuery(target_type_name: "PoseTrack2D")
+
     # Get the list of inference executions
     inferenceExecutions(page: PaginationInput): InferenceExecutionList @beehiveList(target_type_name: "InferenceExecution")
     # Get an inference execution
@@ -447,6 +484,11 @@ extend type Mutation {
     createPose2D(pose2D: Pose2DInput): Pose2D @beehiveCreate(target_type_name: "Pose2D")
     # Delete a 2D pose
     deletePose2D(pose_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "Pose2D")
+
+    # Create a new 2D pose track
+    createPoseTrack2D(poseTrack2D: PoseTrack2DInput): PoseTrack2D @beehiveCreate(target_type_name: "PoseTrack2D")
+    # Delete a 2D pose track
+    deletePoseTrack2D(pose_track_id: ID): DeleteStatusResponse @beehiveDelete(target_type_name: "PoseTrack2D")
 
     tagDatapoint(data_id: ID!, tags: [String!]!): Datapoint! @beehiveListFieldAppend(target_type_name: "Datapoint", field_name: "tags", input_field_name: "tags")
     untagDatapoint(data_id: ID!, tags: [String!]!): Datapoint! @beehiveListFieldDelete(target_type_name: "Datapoint", field_name: "tags", input_field_name: "tags")


### PR DESCRIPTION
I created `PoseTrack2D` and `PoseTrack3D` objects so we have standalone objects with UUIDs to represent the linkages of poses across time. I also added a field to `Pose3D` to capture the 2D poses that inform each 3D pose. For now, these are all just lists of strings into which I'm stuffing IDs. Also, I left the `track_label` fields in `Pose2D` and `Pose3D` for now because I imagine there might be data in those fields that we want to migrate to the corresponding fields in `PoseTrack2D` and `PoseTrack3D`.

If it looks OK , can we merge and deploy?