### PR TITLE
Add environment fields

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     command: "server /data"
     ports:
       - 9000:9000
+      - 9090:9090
     environment:
       MINIO_ACCESS_KEY: myaccesskey
       MINIO_SECRET_KEY: mysecret

--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,12 +2589,12 @@
             "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.25.3.tgz",
             "integrity": "sha512-+eUY2//DLkU7RkJLn6CTl1P89/ZMHuUQnWqv8La2iJ2hLT7Me+nMx+hgHl3LqlT/qDstQ8qA45T85FuCayplmQ==",
             "requires": {
-                "apollo-server-core": "^2.25.3",
-                "apollo-server-express": "^2.25.3",
-                "express": "^4.0.0",
-                "graphql-subscriptions": "^1.0.0",
-                "graphql-tools": "^4.0.8",
-                "stoppable": "^1.1.0"
+                "apollo-server-core": "2.25.3",
+                "apollo-server-express": "2.25.3",
+                "express": "4.16.4",
+                "graphql-subscriptions": "1.1.0",
+                "graphql-tools": "4.0.8",
+                "stoppable": "1.1.0"
             },
             "dependencies": {
                 "@apollo/protobufjs": {
@@ -2602,19 +2602,19 @@
                     "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
                     "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
                     "requires": {
-                        "@protobufjs/aspromise": "^1.1.2",
-                        "@protobufjs/base64": "^1.1.2",
-                        "@protobufjs/codegen": "^2.0.4",
-                        "@protobufjs/eventemitter": "^1.1.0",
-                        "@protobufjs/fetch": "^1.1.0",
-                        "@protobufjs/float": "^1.0.2",
-                        "@protobufjs/inquire": "^1.1.0",
-                        "@protobufjs/path": "^1.1.2",
-                        "@protobufjs/pool": "^1.1.0",
-                        "@protobufjs/utf8": "^1.1.0",
-                        "@types/long": "^4.0.0",
-                        "@types/node": "^10.1.0",
-                        "long": "^4.0.0"
+                        "@protobufjs/aspromise": "1.1.2",
+                        "@protobufjs/base64": "1.1.2",
+                        "@protobufjs/codegen": "2.0.4",
+                        "@protobufjs/eventemitter": "1.1.0",
+                        "@protobufjs/fetch": "1.1.0",
+                        "@protobufjs/float": "1.0.2",
+                        "@protobufjs/inquire": "1.1.0",
+                        "@protobufjs/path": "1.1.2",
+                        "@protobufjs/pool": "1.1.0",
+                        "@protobufjs/utf8": "1.1.0",
+                        "@types/long": "4.0.0",
+                        "@types/node": "10.17.60",
+                        "long": "4.0.0"
                     }
                 },
                 "@apollographql/apollo-tools": {
@@ -2627,7 +2627,7 @@
                     "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.27.tgz",
                     "integrity": "sha512-tea2LweZvn6y6xFV11K0KC8ETjmm52mQrW+ezgB2O/aTQf8JGyFmMcRPFgUaQZeHbWdm8iisDC6EjOKsXu0nfw==",
                     "requires": {
-                        "xss": "^1.0.8"
+                        "xss": "1.0.8"
                     }
                 },
                 "@types/body-parser": {
@@ -2635,8 +2635,8 @@
                     "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
                     "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
                     "requires": {
-                        "@types/connect": "*",
-                        "@types/node": "*"
+                        "@types/connect": "3.4.32",
+                        "@types/node": "10.17.60"
                     }
                 },
                 "@types/cors": {
@@ -2649,10 +2649,10 @@
                     "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
                     "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
                     "requires": {
-                        "@types/body-parser": "*",
-                        "@types/express-serve-static-core": "^4.17.18",
-                        "@types/qs": "*",
-                        "@types/serve-static": "*"
+                        "@types/body-parser": "1.19.0",
+                        "@types/express-serve-static-core": "4.17.24",
+                        "@types/qs": "6.9.3",
+                        "@types/serve-static": "1.13.3"
                     }
                 },
                 "@types/express-serve-static-core": {
@@ -2660,9 +2660,9 @@
                     "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
                     "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
                     "requires": {
-                        "@types/node": "*",
-                        "@types/qs": "*",
-                        "@types/range-parser": "*"
+                        "@types/node": "10.17.60",
+                        "@types/qs": "6.9.3",
+                        "@types/range-parser": "1.2.3"
                     }
                 },
                 "@types/node": {
@@ -2675,8 +2675,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.14.0.tgz",
                     "integrity": "sha512-qN4BCq90egQrgNnTRMUHikLZZAprf3gbm8rC5Vwmc6ZdLolQ7bFsa769Hqi6Tq/lS31KLsXBLTOsRbfPHph12w==",
                     "requires": {
-                        "apollo-server-env": "^3.1.0",
-                        "apollo-server-plugin-base": "^0.13.0"
+                        "apollo-server-env": "3.1.0",
+                        "apollo-server-plugin-base": "0.13.0"
                     }
                 },
                 "apollo-datasource": {
@@ -2684,8 +2684,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.9.0.tgz",
                     "integrity": "sha512-y8H99NExU1Sk4TvcaUxTdzfq2SZo6uSj5dyh75XSQvbpH6gdAXIW9MaBcvlNC7n0cVPsidHmOcHOWxJ/pTXGjA==",
                     "requires": {
-                        "apollo-server-caching": "^0.7.0",
-                        "apollo-server-env": "^3.1.0"
+                        "apollo-server-caching": "0.7.0",
+                        "apollo-server-env": "3.1.0"
                     }
                 },
                 "apollo-graphql": {
@@ -2693,9 +2693,9 @@
                     "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.5.tgz",
                     "integrity": "sha512-RGt5k2JeBqrmnwRM0VOgWFiGKlGJMfmiif/4JvdaEqhMJ+xqe/9cfDYzXfn33ke2eWixsAbjEbRfy8XbaN9nTw==",
                     "requires": {
-                        "core-js-pure": "^3.10.2",
-                        "lodash.sortby": "^4.7.0",
-                        "sha.js": "^2.4.11"
+                        "core-js-pure": "3.19.1",
+                        "lodash.sortby": "4.7.0",
+                        "sha.js": "2.4.11"
                     }
                 },
                 "apollo-reporting-protobuf": {
@@ -2711,7 +2711,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
                     "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
                     "requires": {
-                        "lru-cache": "^6.0.0"
+                        "lru-cache": "6.0.0"
                     }
                 },
                 "apollo-server-core": {
@@ -2719,31 +2719,31 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.25.3.tgz",
                     "integrity": "sha512-Midow3uZoJ9TjFNeCNSiWElTVZlvmB7G7tG6PPoxIR9Px90/v16Q6EzunDIO0rTJHRC3+yCwZkwtf8w2AcP0sA==",
                     "requires": {
-                        "@apollographql/apollo-tools": "^0.5.0",
+                        "@apollographql/apollo-tools": "0.5.2",
                         "@apollographql/graphql-playground-html": "1.6.27",
-                        "@apollographql/graphql-upload-8-fork": "^8.1.3",
-                        "@josephg/resolvable": "^1.0.0",
-                        "@types/ws": "^7.0.0",
-                        "apollo-cache-control": "^0.14.0",
-                        "apollo-datasource": "^0.9.0",
-                        "apollo-graphql": "^0.9.0",
-                        "apollo-reporting-protobuf": "^0.8.0",
-                        "apollo-server-caching": "^0.7.0",
-                        "apollo-server-env": "^3.1.0",
-                        "apollo-server-errors": "^2.5.0",
-                        "apollo-server-plugin-base": "^0.13.0",
-                        "apollo-server-types": "^0.9.0",
-                        "apollo-tracing": "^0.15.0",
-                        "async-retry": "^1.2.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graphql-extensions": "^0.15.0",
-                        "graphql-tag": "^2.11.0",
-                        "graphql-tools": "^4.0.8",
-                        "loglevel": "^1.6.7",
-                        "lru-cache": "^6.0.0",
-                        "sha.js": "^2.4.11",
-                        "subscriptions-transport-ws": "^0.9.19",
-                        "uuid": "^8.0.0"
+                        "@apollographql/graphql-upload-8-fork": "8.1.3",
+                        "@josephg/resolvable": "1.0.1",
+                        "@types/ws": "7.4.0",
+                        "apollo-cache-control": "0.14.0",
+                        "apollo-datasource": "0.9.0",
+                        "apollo-graphql": "0.9.5",
+                        "apollo-reporting-protobuf": "0.8.0",
+                        "apollo-server-caching": "0.7.0",
+                        "apollo-server-env": "3.1.0",
+                        "apollo-server-errors": "2.5.0",
+                        "apollo-server-plugin-base": "0.13.0",
+                        "apollo-server-types": "0.9.0",
+                        "apollo-tracing": "0.15.0",
+                        "async-retry": "1.2.3",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graphql-extensions": "0.15.0",
+                        "graphql-tag": "2.12.6",
+                        "graphql-tools": "4.0.8",
+                        "loglevel": "1.6.8",
+                        "lru-cache": "6.0.0",
+                        "sha.js": "2.4.11",
+                        "subscriptions-transport-ws": "0.9.19",
+                        "uuid": "8.3.2"
                     }
                 },
                 "apollo-server-env": {
@@ -2751,8 +2751,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
                     "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
                     "requires": {
-                        "node-fetch": "^2.6.1",
-                        "util.promisify": "^1.0.0"
+                        "node-fetch": "2.6.6",
+                        "util.promisify": "1.0.0"
                     }
                 },
                 "apollo-server-errors": {
@@ -2766,22 +2766,22 @@
                     "integrity": "sha512-tTFYn0oKH2qqLwVj7Ez2+MiKleXACODiGh5IxsB7VuYCPMAi9Yl8iUSlwTjQUvgCWfReZjnf0vFL2k5YhDlrtQ==",
                     "requires": {
                         "@apollographql/graphql-playground-html": "1.6.27",
-                        "@types/accepts": "^1.3.5",
+                        "@types/accepts": "1.3.5",
                         "@types/body-parser": "1.19.0",
                         "@types/cors": "2.8.10",
-                        "@types/express": "^4.17.12",
-                        "@types/express-serve-static-core": "^4.17.21",
-                        "accepts": "^1.3.5",
-                        "apollo-server-core": "^2.25.3",
-                        "apollo-server-types": "^0.9.0",
-                        "body-parser": "^1.18.3",
-                        "cors": "^2.8.5",
-                        "express": "^4.17.1",
-                        "graphql-subscriptions": "^1.0.0",
-                        "graphql-tools": "^4.0.8",
-                        "parseurl": "^1.3.2",
-                        "subscriptions-transport-ws": "^0.9.19",
-                        "type-is": "^1.6.16"
+                        "@types/express": "4.17.13",
+                        "@types/express-serve-static-core": "4.17.24",
+                        "accepts": "1.3.7",
+                        "apollo-server-core": "2.25.3",
+                        "apollo-server-types": "0.9.0",
+                        "body-parser": "1.18.3",
+                        "cors": "2.8.5",
+                        "express": "4.17.1",
+                        "graphql-subscriptions": "1.1.0",
+                        "graphql-tools": "4.0.8",
+                        "parseurl": "1.3.3",
+                        "subscriptions-transport-ws": "0.9.19",
+                        "type-is": "1.6.18"
                     },
                     "dependencies": {
                         "express": {
@@ -2789,36 +2789,36 @@
                             "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
                             "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
                             "requires": {
-                                "accepts": "~1.3.7",
+                                "accepts": "1.3.7",
                                 "array-flatten": "1.1.1",
                                 "body-parser": "1.19.0",
                                 "content-disposition": "0.5.3",
-                                "content-type": "~1.0.4",
+                                "content-type": "1.0.4",
                                 "cookie": "0.4.0",
                                 "cookie-signature": "1.0.6",
                                 "debug": "2.6.9",
-                                "depd": "~1.1.2",
-                                "encodeurl": "~1.0.2",
-                                "escape-html": "~1.0.3",
-                                "etag": "~1.8.1",
-                                "finalhandler": "~1.1.2",
+                                "depd": "1.1.2",
+                                "encodeurl": "1.0.2",
+                                "escape-html": "1.0.3",
+                                "etag": "1.8.1",
+                                "finalhandler": "1.1.2",
                                 "fresh": "0.5.2",
                                 "merge-descriptors": "1.0.1",
-                                "methods": "~1.1.2",
-                                "on-finished": "~2.3.0",
-                                "parseurl": "~1.3.3",
+                                "methods": "1.1.2",
+                                "on-finished": "2.3.0",
+                                "parseurl": "1.3.3",
                                 "path-to-regexp": "0.1.7",
-                                "proxy-addr": "~2.0.5",
+                                "proxy-addr": "2.0.6",
                                 "qs": "6.7.0",
-                                "range-parser": "~1.2.1",
+                                "range-parser": "1.2.1",
                                 "safe-buffer": "5.1.2",
                                 "send": "0.17.1",
                                 "serve-static": "1.14.1",
                                 "setprototypeof": "1.1.1",
-                                "statuses": "~1.5.0",
-                                "type-is": "~1.6.18",
+                                "statuses": "1.5.0",
+                                "type-is": "1.6.18",
                                 "utils-merge": "1.0.1",
-                                "vary": "~1.1.2"
+                                "vary": "1.1.2"
                             },
                             "dependencies": {
                                 "body-parser": {
@@ -2827,15 +2827,15 @@
                                     "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
                                     "requires": {
                                         "bytes": "3.1.0",
-                                        "content-type": "~1.0.4",
+                                        "content-type": "1.0.4",
                                         "debug": "2.6.9",
-                                        "depd": "~1.1.2",
+                                        "depd": "1.1.2",
                                         "http-errors": "1.7.2",
                                         "iconv-lite": "0.4.24",
-                                        "on-finished": "~2.3.0",
+                                        "on-finished": "2.3.0",
                                         "qs": "6.7.0",
                                         "raw-body": "2.4.0",
-                                        "type-is": "~1.6.17"
+                                        "type-is": "1.6.18"
                                     }
                                 }
                             }
@@ -2847,7 +2847,7 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.13.0.tgz",
                     "integrity": "sha512-L3TMmq2YE6BU6I4Tmgygmd0W55L+6XfD9137k+cWEBFu50vRY4Re+d+fL5WuPkk5xSPKd/PIaqzidu5V/zz8Kg==",
                     "requires": {
-                        "apollo-server-types": "^0.9.0"
+                        "apollo-server-types": "0.9.0"
                     }
                 },
                 "apollo-server-types": {
@@ -2855,9 +2855,9 @@
                     "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
                     "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
                     "requires": {
-                        "apollo-reporting-protobuf": "^0.8.0",
-                        "apollo-server-caching": "^0.7.0",
-                        "apollo-server-env": "^3.1.0"
+                        "apollo-reporting-protobuf": "0.8.0",
+                        "apollo-server-caching": "0.7.0",
+                        "apollo-server-env": "3.1.0"
                     }
                 },
                 "apollo-tracing": {
@@ -2865,8 +2865,8 @@
                     "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.15.0.tgz",
                     "integrity": "sha512-UP0fztFvaZPHDhIB/J+qGuy6hWO4If069MGC98qVs0I8FICIGu4/8ykpX3X3K6RtaQ56EDAWKykCxFv4ScxMeA==",
                     "requires": {
-                        "apollo-server-env": "^3.1.0",
-                        "apollo-server-plugin-base": "^0.13.0"
+                        "apollo-server-env": "3.1.0",
+                        "apollo-server-plugin-base": "0.13.0"
                     }
                 },
                 "bytes": {
@@ -2887,9 +2887,9 @@
                     "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.15.0.tgz",
                     "integrity": "sha512-bVddVO8YFJPwuACn+3pgmrEg6I8iBuYLuwvxiE+lcQQ7POotVZxm2rgGw0PvVYmWWf3DT7nTVDZ5ROh/ALp8mA==",
                     "requires": {
-                        "@apollographql/apollo-tools": "^0.5.0",
-                        "apollo-server-env": "^3.1.0",
-                        "apollo-server-types": "^0.9.0"
+                        "@apollographql/apollo-tools": "0.5.2",
+                        "apollo-server-env": "3.1.0",
+                        "apollo-server-types": "0.9.0"
                     }
                 },
                 "graphql-tag": {
@@ -2897,7 +2897,7 @@
                     "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
                     "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
                     "requires": {
-                        "tslib": "^2.1.0"
+                        "tslib": "2.3.1"
                     }
                 },
                 "http-errors": {
@@ -2905,10 +2905,10 @@
                     "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
                     "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
                     "requires": {
-                        "depd": "~1.1.2",
+                        "depd": "1.1.2",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.1.1",
-                        "statuses": ">= 1.5.0 < 2",
+                        "statuses": "1.5.0",
                         "toidentifier": "1.0.0"
                     }
                 },
@@ -2922,7 +2922,7 @@
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
                     "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
                     "requires": {
-                        "yallist": "^4.0.0"
+                        "yallist": "4.0.0"
                     }
                 },
                 "ms": {
@@ -2935,7 +2935,7 @@
                     "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
                     "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
                     "requires": {
-                        "whatwg-url": "^5.0.0"
+                        "whatwg-url": "5.0.0"
                     }
                 },
                 "qs": {
@@ -2964,11 +2964,11 @@
                     "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
                     "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
                     "requires": {
-                        "backo2": "^1.0.2",
-                        "eventemitter3": "^3.1.0",
-                        "iterall": "^1.2.1",
-                        "symbol-observable": "^1.0.4",
-                        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+                        "backo2": "1.0.2",
+                        "eventemitter3": "3.1.2",
+                        "iterall": "1.2.2",
+                        "symbol-observable": "1.2.0",
+                        "ws": "6.2.1"
                     }
                 },
                 "tslib": {
@@ -8765,7 +8765,7 @@
                         "rimraf": "2.7.1",
                         "ssri": "6.0.1",
                         "unique-filename": "1.1.1",
-                        "y18n": "4.0.0"
+                        "y18n": "4.0.1"
                     }
                 },
                 "call-limit": {
@@ -10184,7 +10184,7 @@
                         "safe-buffer": "5.1.2",
                         "update-notifier": "2.5.0",
                         "which": "1.3.1",
-                        "y18n": "4.0.0",
+                        "y18n": "4.0.1",
                         "yargs": "11.1.1"
                     }
                 },
@@ -11907,7 +11907,7 @@
                         "set-blocking": "2.0.0",
                         "string-width": "2.1.1",
                         "which-module": "2.0.0",
-                        "y18n": "3.2.1",
+                        "y18n": "3.2.2",
                         "yargs-parser": "9.0.2"
                     },
                     "dependencies": {
@@ -14424,8 +14424,8 @@
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
             "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "tr46": "0.0.3",
+                "webidl-conversions": "3.0.1"
             }
         },
         "which": {
@@ -14565,7 +14565,7 @@
                 "set-blocking": "2.0.0",
                 "string-width": "3.1.0",
                 "which-module": "2.0.0",
-                "y18n": "4.0.0",
+                "y18n": "4.0.1",
                 "yargs-parser": "13.1.2"
             },
             "dependencies": {

--- a/src/schema/environments.js
+++ b/src/schema/environments.js
@@ -2,10 +2,13 @@ exports.typeDefs = `
 
   type Environment @beehiveTable(table_name: "environments", pk_column: "environment_id") {
     environment_id: ID!
-    name: String!,
+    name: String!
+    display_name: String
     transparent_classroom_id: Int
     description: String
     location: String
+    timezone_name: String
+    timezone_abbreviation: String
     assignments: [Assignment!] @beehiveAssignmentFilter(target_type_name: "Assignment", assignee_field: "environment")
     layouts: [Layout!] @beehiveAssignmentFilter(target_type_name: "Layout", assignee_field: "environment")
   }
@@ -17,16 +20,22 @@ exports.typeDefs = `
 
   input EnvironmentInput {
     name: String!
+    display_name: String
     transparent_classroom_id: Int
     description: String
     location: String
+    timezone_name: String
+    timezone_abbreviation: String
   }
 
   input EnvironmentUpdateInput {
     name: String
+    display_name: String
     transparent_classroom_id: Int
     description: String
     location: String
+    timezone_name: String
+    timezone_abbreviation: String
   }
 
   type Person @beehiveTable(table_name: "persons", pk_column: "person_id") {
@@ -246,7 +255,7 @@ exports.typeDefs = `
     # Get an environment
     getEnvironment(environment_id: ID!): Environment @beehiveGet(target_type_name: "Environment")
     # Find environments based on one or more of their properties
-    findEnvironments(name: String, transparent_classroom_id: Int, location: String, page: PaginationInput): EnvironmentList @beehiveSimpleQuery(target_type_name: "Environment")
+    findEnvironments(name: String, display_name: String, transparent_classroom_id: Int, location: String, page: PaginationInput): EnvironmentList @beehiveSimpleQuery(target_type_name: "Environment")
     # Find environments based on one or more of their properties (DEPRECATED, use findEnvironments instead)
     findEnvironment(name: String, location: String): EnvironmentList @beehiveSimpleQuery(target_type_name: "Environment")
     # Find environments using a complex query


### PR DESCRIPTION
Adding three new fields to the `environment` object:

- `display_name`: I'm thinking this should be a human-formatted short name ("Greenbrier"), not the full legal/TC name ("Greenbrier Montessori School"), but happy to discuss
- `timezone_name`: This should be an IANA name, but I don't know whether or how to impose that constraint within the schema
- `timezone_abbreviation`: This should be the local abbreviation, so it looks sensible to users in the environment

This has been tested on a local deployment of Honeycomb.